### PR TITLE
Fix React types detection

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,12 @@
     "esModuleInterop": true,
     "strictNullChecks": true,
     "resolveJsonModule": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
+    "types": [
+      "node",
+      "react",
+      "react-dom"
+    ],
     "lib": [
       "DOM",
       "ES5",


### PR DESCRIPTION
## Summary
- update TypeScript options to load React and Node type definitions

## Testing
- `npm run lint` *(fails: numerous no-undef errors)*
- `npm test`
- `npm run build`
