### PR TITLE
Fix type export conflict

### DIFF
--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -1,5 +1,8 @@
-export interface TimelineProject {
-  name: string;
-  modified?: boolean;
-}
+// Re-export the TimelineProject definition from usd.ts for convenience.
+// Using `export type` avoids issues with `isolatedModules` in the TypeScript
+// configuration.
+export type { TimelineProject } from './usd';
+
+// Additional timeline specific types can be added below as needed.
+
 


### PR DESCRIPTION
## Summary
- re-export `TimelineProject` as a type in `timeline.ts` to avoid conflict when `isolatedModules` is enabled

## Testing
- `npm test` *(fails: Could not find test files)*
- `npm run build`