### PR TITLE
Fix type re-export issue

### DIFF
--- a/src/types/usd.ts
+++ b/src/types/usd.ts
@@ -94,7 +94,7 @@ export interface UsdProject {
 }
 
 // Simplified project structure for timeline UI compatibility
-export interface TimelineProject {
+export type TimelineProject = {
   schemaIdentifier: string; // "usd" 
   schemaVersion: string; // "1.0"
   name: string;


### PR DESCRIPTION
## Summary
- refactor `TimelineProject` declaration in `usd.ts` to a type alias
- ensure newline at file end

## Testing
- `npx tsc --noEmit` *(fails: TypeScript errors in unrelated files)*
- `npm run lint` *(fails: multiple lint errors)*