### PR TITLE
Improve Tool interface with generics

### DIFF
--- a/src/service-api/api/usd-tool/convert-md-to-usd.ts
+++ b/src/service-api/api/usd-tool/convert-md-to-usd.ts
@@ -104,8 +104,6 @@ namespace Internal {
     console.log('Content:', processedMarkdown);
     console.log('Length:', processedMarkdown.length);
 
-    let finalUsdaContent: string;
-
     // 常に新しいUSDプロジェクトを作成（既存のUSDAは参考程度）
     console.log('=== Creating new USD project ===');
     console.log('processedMarkdown:', processedMarkdown);
@@ -113,7 +111,7 @@ namespace Internal {
     const usdProject = createEmptyUsdProject(processedMarkdown);
     console.log('=== USD Project sourceMarkdown ===');
     console.log(usdProject.applicationMetadata.sourceMarkdown);
-    finalUsdaContent = UsdGenerator.generateUsdaContent(usdProject);
+    const finalUsdaContent = UsdGenerator.generateUsdaContent(usdProject);
 
     // 元のファイルをUSDに置き換え
     const parentPath = file.parent?.path || '';

--- a/src/service-api/core/tool-executor.ts
+++ b/src/service-api/core/tool-executor.ts
@@ -3,11 +3,11 @@ import { ToolsConfiguration } from './tool-config-types';
 
 namespace Internal {
   export let config: ToolsConfiguration;
-  export let tools: Map<string, Tool>;
+  export let tools: Map<string, Tool<any, any>>;
   export let aiEnabledTools: Set<string>;
 
   export function initialize(
-    toolsMap: Map<string, Tool>, 
+    toolsMap: Map<string, Tool<any, any>>,
     aiToolsSet: Set<string>, 
     configuration: ToolsConfiguration
   ): void {
@@ -20,14 +20,17 @@ namespace Internal {
 export class ToolExecutor {
   
   static initialize(
-    tools: Map<string, Tool>, 
-    aiEnabledTools: Set<string>, 
+    tools: Map<string, Tool<any, any>>,
+    aiEnabledTools: Set<string>,
     config: ToolsConfiguration
   ): void {
     Internal.initialize(tools, aiEnabledTools, config);
   }
 
-  static async executeTool(name: string, args: Record<string, unknown>): Promise<string> {
+  static async executeTool<TInput = Record<string, unknown>, TOutput = string>(
+    name: string,
+    args: TInput
+  ): Promise<TOutput> {
     const tool = Internal.tools.get(name);
     if (!tool) {
       const availableTools = Array.from(Internal.tools.keys()).join(', ');
@@ -37,7 +40,7 @@ export class ToolExecutor {
     try {
       if (Internal.config.config.enableLogging) {
       }
-      const result = await tool.execute(args);
+      const result = await (tool as Tool<TInput, TOutput>).execute(args);
       if (Internal.config.config.enableLogging) {
       }
       return result;
@@ -56,7 +59,7 @@ export class ToolExecutor {
     return Internal.tools.has(name);
   }
 
-  static getTool(name: string): Tool | undefined {
+  static getTool(name: string): Tool<any, any> | undefined {
     return Internal.tools.get(name);
   }
-} 
+}

--- a/src/service-api/core/tool-registry.ts
+++ b/src/service-api/core/tool-registry.ts
@@ -29,11 +29,11 @@ import { toggleLayerVisibilityTool } from '../api/layer-tool/toggle-layer-visibi
 import { addLayerTool } from '../api/layer-tool/add-layer';
 
 namespace Internal {
-  export const tools = new Map<string, Tool>();
+  export const tools = new Map<string, Tool<any, any>>();
   export const aiEnabledTools = new Set<string>();
   export const config: ToolsConfiguration = TOOLS_CONFIG as ToolsConfiguration;
 
-  export const staticTools: Record<string, Tool<any>> = {
+  export const staticTools: Record<string, Tool<any, any>> = {
     [TOOL_NAMES.CREATE_STORYBOARD_FILE]: createStoryboardFileTool,
     [TOOL_NAMES.RENAME_FILE_EXTENSION]: renameFileExtensionTool,
     [TOOL_NAMES.TOGGLE_STORYBOARD_VIEW]: toggleStoryboardViewTool,
@@ -99,7 +99,7 @@ namespace Internal {
     }
   }
 
-  export function registerToolInternal(tool: Tool): void {
+  export function registerToolInternal(tool: Tool<any, any>): void {
     if (tools.has(tool.name)) {
       if (config.config.enableLogging) {
       }
@@ -146,15 +146,15 @@ export class ToolRegistry {
     }
   }
 
-  getTool(name: string): Tool | undefined {
+  getTool(name: string): Tool<any, any> | undefined {
     return ToolExecutor.getTool(name);
   }
 
-  getAllTools(): Tool[] {
+  getAllTools(): Tool<any, any>[] {
     return Array.from(Internal.tools.values());
   }
 
-  getAiEnabledTools(): Tool[] {
+  getAiEnabledTools(): Tool<any, any>[] {
     return this.getAllTools().filter(tool => Internal.aiEnabledTools.has(tool.name));
   }
 
@@ -174,8 +174,11 @@ export class ToolRegistry {
     return ToolExecutor.isAiEnabled(name);
   }
 
-  async executeTool(name: string, args: Record<string, unknown>): Promise<string> {
-    return ToolExecutor.executeTool(name, args);
+  async executeTool<TInput = Record<string, unknown>, TOutput = string>(
+    name: string,
+    args: TInput
+  ): Promise<TOutput> {
+    return ToolExecutor.executeTool<TInput, TOutput>(name, args);
   }
 
   printToolInfo(): void {

--- a/src/service-api/core/tool.ts
+++ b/src/service-api/core/tool.ts
@@ -1,4 +1,4 @@
-export interface Tool<TInput = Record<string, unknown>> {
+export interface Tool<TInput = Record<string, unknown>, TOutput = string> {
   
   name: string;
   
@@ -6,5 +6,5 @@ export interface Tool<TInput = Record<string, unknown>> {
   
   parameters: Record<string, unknown>;
   
-  execute: (args: TInput) => Promise<string>;
+  execute: (args: TInput) => Promise<TOutput>;
 }


### PR DESCRIPTION
## Summary
- support generic output type in Tool
- update ToolExecutor and ToolRegistry to handle generic outputs
- fix lint issues

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Could not find 'test/**/*.test.js')*