### PR TITLE
Use dynamic import for tools

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -20,8 +20,8 @@ export default class MyPlugin extends Plugin {
 
     setAppInstance(this.app);
 
-
-    
+    // ツールの登録完了を待つ
+    await toolRegistry.ready;
     const availableTools = toolRegistry.getRegisteredToolNames();
 
     if (availableTools.length === 0) {

--- a/src/service-api/api/usd-tool/convert-md-to-usd.ts
+++ b/src/service-api/api/usd-tool/convert-md-to-usd.ts
@@ -104,7 +104,6 @@ namespace Internal {
     console.log('Content:', processedMarkdown);
     console.log('Length:', processedMarkdown.length);
 
-    let finalUsdaContent: string;
 
     // 常に新しいUSDプロジェクトを作成（既存のUSDAは参考程度）
     console.log('=== Creating new USD project ===');
@@ -113,7 +112,7 @@ namespace Internal {
     const usdProject = createEmptyUsdProject(processedMarkdown);
     console.log('=== USD Project sourceMarkdown ===');
     console.log(usdProject.applicationMetadata.sourceMarkdown);
-    finalUsdaContent = UsdGenerator.generateUsdaContent(usdProject);
+    const finalUsdaContent = UsdGenerator.generateUsdaContent(usdProject);
 
     // 元のファイルをUSDに置き換え
     const parentPath = file.parent?.path || '';


### PR DESCRIPTION
## Summary
- refactor tool-registry to dynamically load tools
- wait for tools to be ready before accessing them
- fix lint issue in convert-md-to-usd

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Could not find '/workspace/obsidian_storyboard/test/**/*.test.js')*